### PR TITLE
adapt SLICOT models to changes in Reachability.jl

### DIFF
--- a/models/SLICOT/beam/beam.jl
+++ b/models/SLICOT/beam/beam.jl
@@ -3,7 +3,7 @@ Model: beam.jl
 
 This is a 348-variable model.
 =#
-using Reachability, LazySets, MAT
+using Reachability, MAT, Plots
 
 function compute(input_options::Pair{Symbol,<:Any}...)
     # =====================

--- a/models/SLICOT/beam/beam.jl
+++ b/models/SLICOT/beam/beam.jl
@@ -13,7 +13,7 @@ function compute(input_options::Options)
     # Problem specification
     # =====================
     file = matopen(@relpath "beam.mat")
-    A = sparse(read(file, "A"))
+    A = read(file, "A")
 
     # initial set
     # - x1-x300 are 0.0,
@@ -21,7 +21,7 @@ function compute(input_options::Options)
     X0 = Hyperrectangle([zeros(300); fill(0.00175, 48)], [zeros(300); fill(0.00025, 48)])
 
     # input set
-    B = sparse(read(file, "B"))
+    B = read(file, "B")
     U = B * BallInf([0.5], 0.3)
 
     # instantiate continuous LTI system
@@ -32,8 +32,8 @@ function compute(input_options::Options)
     # ===============
     if input_options[:mode] == "reach"
         problem_options = Options(:vars => [89],
-                                 :partition => [(2*i-1:2*i) for i in 1:174],
-                                 :plot_vars => [0, 89])
+                                  :partition => [(2*i-1:2*i) for i in 1:174],
+                                  :plot_vars => [0, 89])
 
     elseif input_options[:mode] == "check"
         problem_options = Options(:vars => [89],

--- a/models/SLICOT/beam/beam.jl
+++ b/models/SLICOT/beam/beam.jl
@@ -32,7 +32,8 @@ function compute(input_options::Pair{Symbol,<:Any}...)
     options = merge(Options(
         :mode => "reach",
         :property => LinearConstraintProperty([1., 0.], 2100.), # x89 < 2100
-        :blocks => [@block_id(89)],
+        :vars => [89], # variable needed for property
+        :partition => [(2*i-1:2*i) for i in 1:174], # 2D blocks
         :plot_vars => [0, 89]
         ), Options(input_options...))
 
@@ -47,8 +48,8 @@ function compute(input_options::Pair{Symbol,<:Any}...)
         plot(result)
         @eval(savefig(@filename_to_png))
         toc()
-    en
+    end
 end # function
 
-compute(:N => 10, :T => 20.0); # warm-up
+compute(:δ => 0.0005, :N => 3); # warm-up
 compute(:δ => 0.0005, :T => 20.0); # benchmark settings (long)

--- a/models/SLICOT/building/building.jl
+++ b/models/SLICOT/building/building.jl
@@ -5,7 +5,7 @@ See also:
 bak2017cav_repeatability or
 [Building example in Hylaa](https://github.com/stanleybak/hylaa/blob/master/examples/building/building.py)
 =#
-using Reachability, LazySets, MAT
+using Reachability, MAT, Plots
 
 function compute(input_options::Pair{Symbol,<:Any}...)
     # =====================

--- a/models/SLICOT/building/building.jl
+++ b/models/SLICOT/building/building.jl
@@ -39,7 +39,7 @@ function compute(input_options::Pair{Symbol,<:Any}...)
         :mode => "reach",
         :property => LinearConstraintProperty([1., 0.], 6e-3), # x25 < 6e-3
         :vars => [25], # variable needed for property
-        :partition=> [(2*i-1:2*i) for i in 1:24], # 2D blocks
+        :partition => [(2*i-1:2*i) for i in 1:24], # 2D blocks
         :plot_vars => [0, 25]
         ), Options(input_options...))
 

--- a/models/SLICOT/building/building.jl
+++ b/models/SLICOT/building/building.jl
@@ -37,12 +37,12 @@ function compute(input_options::Options)
     # ===============
     if input_options[:mode] == "reach"
         problem_options = Options(:vars => [25],
-                                 :partition => [(2*i-1:2*i) for i in 1:24],
-                                 :plot_vars => [0, 25])
+                                  :partition => [(2*i-1:2*i) for i in 1:24],
+                                  :plot_vars => [0, 25])
     elseif input_options[:mode] == "check"
         problem_options = Options(:vars => [25],
-                                 :partition => [(2*i-1:2*i) for i in 1:24],
-                                 :property => LinearConstraintProperty(sparsevec([25], [1.0], 48), 6e-3)) # x25 < 6e-3
+                                  :partition => [(2*i-1:2*i) for i in 1:24],
+                                  :property => LinearConstraintProperty(sparsevec([25], [1.0], 48), 6e-3)) # x25 < 6e-3
     end
 
     result = solve(S, merge(input_options, problem_options))

--- a/models/SLICOT/building/building.jl
+++ b/models/SLICOT/building/building.jl
@@ -7,12 +7,14 @@ bak2017cav_repeatability or
 =#
 using Reachability, MAT, Plots
 
-function compute(input_options::Pair{Symbol,<:Any}...)
+compute(o::Pair{Symbol,<:Any}...) = compute(Options(Dict{Symbol,Any}(o)))
+
+function compute(input_options::Options)
     # =====================
     # Problem specification
     # =====================
     file = matopen(@relpath "building.mat")
-    A = sparse(read(file, "A"))
+    A = read(file, "A")
 
     # initial set
     # - x1-x10 are in [0.0002, 0.00025],
@@ -24,7 +26,7 @@ function compute(input_options::Pair{Symbol,<:Any}...)
     # X0 = CartesianProductArray([BallInf(fill(0.000225, 10), 0.000025), Singleton(zeros(14)), BallInf([0.], 0.0001), Singleton(zeros(23))])
 
     # input set
-    B = sparse(read(file, "B"))
+    B = read(file, "B")
     U = B * BallInf([0.9], .1)
 
     # instantiate continuous LTI system
@@ -33,29 +35,30 @@ function compute(input_options::Pair{Symbol,<:Any}...)
     # ===============
     # Problem solving
     # ===============
+    if input_options[:mode] == "reach"
+        problem_options = Options(:vars => [25],
+                                 :partition => [(2*i-1:2*i) for i in 1:24],
+                                 :plot_vars => [0, 25])
+    elseif input_options[:mode] == "check"
+        problem_options = Options(:vars => [25],
+                                 :partition => [(2*i-1:2*i) for i in 1:24],
+                                 :property => LinearConstraintProperty(sparsevec([25], [1.0], 48), 6e-3)) # x25 < 6e-3
+    end
 
-    # define solver-specific options
-    options = merge(Options(
-        :mode => "reach",
-        :property => LinearConstraintProperty([1., 0.], 6e-3), # x25 < 6e-3
-        :vars => [25], # variable needed for property
-        :partition => [(2*i-1:2*i) for i in 1:24], # 2D blocks
-        :plot_vars => [0, 25]
-        ), Options(input_options...))
-
-    result = solve(S, options)
+    result = solve(S, merge(input_options, problem_options))
 
     # ========
     # Plotting
     # ========
-    if options[:mode] == "reach"
+    if input_options[:mode] == "reach"
         println("Plotting...")
         tic()
         plot(result)
-        @eval(savefig(@filename_to_png))
+        @eval(savefig(@relpath "building.png"))
         toc()
     end
 end # function
 
-compute(:δ => 0.002, :N => 3); # warm-up
-compute(:δ => 0.002, :T => 20.0); # benchmark settings (long)
+# Reach tube computation in dense time
+compute(:δ => 1e-3, :N => 3, :mode=>"reach", :verbosity => "info"); # warm-up
+compute(:δ => 1e-3, :T => 20.0, :mode=>"reach", :verbosity => "info"); # benchmark settings (long)

--- a/models/SLICOT/building/building.jl
+++ b/models/SLICOT/building/building.jl
@@ -38,7 +38,8 @@ function compute(input_options::Pair{Symbol,<:Any}...)
     options = merge(Options(
         :mode => "reach",
         :property => LinearConstraintProperty([1., 0.], 6e-3), # x25 < 6e-3
-        :blocks => [@block_id(25)],
+        :vars => [25], # variable needed for property
+        :partition=> [(2*i-1:2*i) for i in 1:24], # 2D blocks
         :plot_vars => [0, 25]
         ), Options(input_options...))
 
@@ -56,5 +57,5 @@ function compute(input_options::Pair{Symbol,<:Any}...)
     end
 end # function
 
-compute(:N => 10, :T => 20.0); # warm-up
+compute(:δ => 0.002, :N => 3); # warm-up
 compute(:δ => 0.002, :T => 20.0); # benchmark settings (long)

--- a/models/SLICOT/cdplayer/cdplayer.jl
+++ b/models/SLICOT/cdplayer/cdplayer.jl
@@ -32,7 +32,7 @@ function compute(input_options::Pair{Symbol,<:Any}...)
         :property => LinearConstraintProperty([2., -3.], 450.8), # 2*x1 -3*x2 < 450.8
 #       :vars => [1], # variable for single block analysis
         :vars => [1, 2], # variables needed for property
-        :partition=> [(2*i-1:2*i) for i in 1:60], # 2D blocks
+        :partition => [(2*i-1:2*i) for i in 1:60], # 2D blocks
         :assume_sparse => true,
         :plot_vars => [0, 1]
         ), Options(input_options...))

--- a/models/SLICOT/cdplayer/cdplayer.jl
+++ b/models/SLICOT/cdplayer/cdplayer.jl
@@ -3,7 +3,7 @@ Model: cdplayer.jl
 
 This is a 120-variable model.
 =#
-using Reachability, MAT
+using Reachability, MAT, Plots
 
 function compute(input_options::Pair{Symbol,<:Any}...)
     # =====================

--- a/models/SLICOT/cdplayer/cdplayer.jl
+++ b/models/SLICOT/cdplayer/cdplayer.jl
@@ -30,7 +30,9 @@ function compute(input_options::Pair{Symbol,<:Any}...)
     options = merge(Options(
         :mode => "reach",
         :property => LinearConstraintProperty([2., -3.], 450.8), # 2*x1 -3*x2 < 450.8
-        :blocks => [1],
+#       :vars => [1], # variable for single block analysis
+        :vars => [1, 2], # variables needed for property
+        :partition=> [(2*i-1:2*i) for i in 1:60], # 2D blocks
         :assume_sparse => true,
         :plot_vars => [0, 1]
         ), Options(input_options...))
@@ -49,6 +51,6 @@ function compute(input_options::Pair{Symbol,<:Any}...)
     end
 end # function
 
-compute(:N => 10, :T => 20.0); # warm-up
+compute(:δ => 0.0001, :N => 3); # warm-up
 compute(:δ => 0.0001, :T => 20.0); # benchmark settings (long)
 

--- a/models/SLICOT/fom/fom.jl
+++ b/models/SLICOT/fom/fom.jl
@@ -30,7 +30,9 @@ function compute(input_options::Pair{Symbol,<:Any}...)
     options = merge(Options(
         :mode => "reach",
         :property => LinearConstraintProperty(read(matopen(@relpath "out.mat"), "M")[1,:], 185.), # y < 185
-#       :blocks => [1],
+#       :vars => [1], # variable for single block analysis
+        :vars => 1:1006, # variables needed for property
+        :partition=> [(2*i-1:2*i) for i in 1:503], # 2D blocks
         :assume_sparse => true,
 #       :projection_matrix => sparse(read(matopen(@relpath "out.mat"), "M")),
         :plot_vars => [0, 1]
@@ -50,5 +52,5 @@ function compute(input_options::Pair{Symbol,<:Any}...)
     end
 end # function
 
-compute(:N => 10, :T => 20.0); # warm-up
+compute(:δ => 0.05, :N => 3); # warm-up
 compute(:δ => 0.05, :T => 20.0); # benchmark settings (long)

--- a/models/SLICOT/fom/fom.jl
+++ b/models/SLICOT/fom/fom.jl
@@ -5,18 +5,20 @@ This is a 1006 x 1006 dimensional model with 1 input.
 =#
 using Reachability, MAT, Plots
 
-function compute(input_options::Pair{Symbol,<:Any}...)
+compute(o::Pair{Symbol,<:Any}...) = compute(Options(Dict{Symbol,Any}(o)))
+
+function compute(input_options::Options)
     # =====================
     # Problem specification
     # =====================
     file = matopen(@relpath "fom.mat")
-    A = sparse(read(file, "A"))*1.0  # this model provides a matrix with Int components
+    A = read(file, "A")*1.0  # this model provides a matrix with Int components
 
     # initial set
     X0 = Hyperrectangle(zeros(1006), [fill(0.0001, 400); zeros(606)])
 
     # input set
-    B = sparse(read(file, "B"))
+    B = read(file, "B")
     U = B * BallInf([0.0], 1.0)
 
     # instantiate continuous LTI system
@@ -25,32 +27,33 @@ function compute(input_options::Pair{Symbol,<:Any}...)
     # ===============
     # Problem solving
     # ===============
-
-    # define solver-specific options
-    options = merge(Options(
-        :mode => "reach",
-        :property => LinearConstraintProperty(read(matopen(@relpath "out.mat"), "M")[1,:], 185.), # y < 185
-#       :vars => [1], # variable for single block analysis
-        :vars => 1:1006, # variables needed for property
-        :partition => [(2*i-1:2*i) for i in 1:503], # 2D blocks
-        :assume_sparse => true,
-#       :projection_matrix => sparse(read(matopen(@relpath "out.mat"), "M")),
-        :plot_vars => [0, 1]
-        ), Options(input_options...))
-
-    result = solve(S, options)
+    if input_options[:mode] == "reach"
+        problem_options = Options(:vars => [1],
+                                  :partition => [(2*i-1:2*i) for i in 1:503], # 2D blocks
+                                  :plot_vars => [0, 1],
+                                  :assume_sparse => true)
+        # :projection_matrix => sparse(read(matopen(@relpath "out.mat"), "M")),
+    elseif input_options[:mode] == "check"
+        problem_options = Options(:vars => 1:1006, # variables needed for property
+                                  :partition => [(2*i-1:2*i) for i in 1:503], # 2D blocks
+                                  :property => LinearConstraintProperty(read(matopen(@relpath "out.mat"), "M")[1,:], 185.), # y < 185
+                                  :assume_sparse => true)
+    end
+ 
+    result = solve(S, merge(input_options, problem_options))
 
     # ========
     # Plotting
     # ========
-    if options[:mode] == "reach"
+    if input_options[:mode] == "reach"
         println("Plotting...")
         tic()
         plot(result)
-        @eval(savefig(@filename_to_png))
+        @eval(savefig(@relpath "fom.png"))
         toc()
     end
 end # function
 
-compute(:δ => 0.05, :N => 3); # warm-up
-compute(:δ => 0.05, :T => 20.0); # benchmark settings (long)
+# Reach tube computation in dense time
+compute(:δ => 1e-3, :N => 3, :mode=>"reach", :verbosity => "info"); # warm-up
+compute(:δ => 1e-3, :T => 20.0, :mode=>"reach", :verbosity => "info"); # benchmark settings (long)

--- a/models/SLICOT/fom/fom.jl
+++ b/models/SLICOT/fom/fom.jl
@@ -3,7 +3,7 @@ Model: fom.jl
 
 This is a 1006 x 1006 dimensional model with 1 input.
 =#
-using Reachability, MAT
+using Reachability, MAT, Plots
 
 function compute(input_options::Pair{Symbol,<:Any}...)
     # =====================
@@ -46,7 +46,7 @@ function compute(input_options::Pair{Symbol,<:Any}...)
     if options[:mode] == "reach"
         println("Plotting...")
         tic()
-        plot(result) # TODO: project_output
+        plot(result)
         @eval(savefig(@filename_to_png))
         toc()
     end

--- a/models/SLICOT/fom/fom.jl
+++ b/models/SLICOT/fom/fom.jl
@@ -32,7 +32,7 @@ function compute(input_options::Pair{Symbol,<:Any}...)
         :property => LinearConstraintProperty(read(matopen(@relpath "out.mat"), "M")[1,:], 185.), # y < 185
 #       :vars => [1], # variable for single block analysis
         :vars => 1:1006, # variables needed for property
-        :partition=> [(2*i-1:2*i) for i in 1:503], # 2D blocks
+        :partition => [(2*i-1:2*i) for i in 1:503], # 2D blocks
         :assume_sparse => true,
 #       :projection_matrix => sparse(read(matopen(@relpath "out.mat"), "M")),
         :plot_vars => [0, 1]

--- a/models/SLICOT/heat/heat.jl
+++ b/models/SLICOT/heat/heat.jl
@@ -33,7 +33,7 @@ function compute(input_options::Pair{Symbol,<:Any}...)
         :mode => "reach",
         :property => LinearConstraintProperty([1., 0.], 0.1), # x133 < 0.1
         :vars => [133], # variable needed for property
-        :partition=> [(2*i-1:2*i) for i in 1:100], # 2D blocks
+        :partition => [(2*i-1:2*i) for i in 1:100], # 2D blocks
         :plot_vars => [0, 133]
         ), Options(input_options...))
 

--- a/models/SLICOT/heat/heat.jl
+++ b/models/SLICOT/heat/heat.jl
@@ -32,7 +32,8 @@ function compute(input_options::Pair{Symbol,<:Any}...)
     options = merge(Options(
         :mode => "reach",
         :property => LinearConstraintProperty([1., 0.], 0.1), # x133 < 0.1
-        :blocks => [@block_id(133)],
+        :vars => [133], # variable needed for property
+        :partition=> [(2*i-1:2*i) for i in 1:100], # 2D blocks
         :plot_vars => [0, 133]
         ), Options(input_options...))
 
@@ -50,5 +51,5 @@ function compute(input_options::Pair{Symbol,<:Any}...)
     end
 end # function
 
-compute(:N => 10, :T => 20.0); # warm-up
+compute(:δ => 0.001, :N => 3); # warm-up
 compute(:δ => 0.001, :T => 20.0); # benchmark settings (long)

--- a/models/SLICOT/heat/heat.jl
+++ b/models/SLICOT/heat/heat.jl
@@ -5,12 +5,14 @@ This is a 200-variable model.
 =#
 using Reachability, MAT, Plots
 
-function compute(input_options::Pair{Symbol,<:Any}...)
+compute(o::Pair{Symbol,<:Any}...) = compute(Options(Dict{Symbol,Any}(o)))
+
+function compute(input_options::Options)
     # =====================
     # Problem specification
     # =====================
     file = matopen(@relpath "heat.mat")
-    A = sparse(read(file, "A"))
+    A = read(file, "A")
 
     # initial set
     # - x1-x300 are 0.0,
@@ -27,29 +29,30 @@ function compute(input_options::Pair{Symbol,<:Any}...)
     # ===============
     # Problem solving
     # ===============
+    if input_options[:mode] == "reach"
+        problem_options = Options(:vars => [133],
+                                  :partition => [(2*i-1:2*i) for i in 1:100],
+                                  :plot_vars => [0, 133])
+    elseif input_options[:mode] == "check"
+        problem_options = Options(:vars => [133], # variables needed for property
+                                  :partition => [(2*i-1:2*i) for i in 1:100],
+                                  :property => LinearConstraintProperty(sparsevec([133], [1.0], 200), 0.1)) # x133 < 0.1
+    end
 
-    # define solver-specific options
-    options = merge(Options(
-        :mode => "reach",
-        :property => LinearConstraintProperty([1., 0.], 0.1), # x133 < 0.1
-        :vars => [133], # variable needed for property
-        :partition => [(2*i-1:2*i) for i in 1:100], # 2D blocks
-        :plot_vars => [0, 133]
-        ), Options(input_options...))
-
-    result = solve(S, options)
+    result = solve(S, merge(input_options, problem_options))
 
     # ========
     # Plotting
     # ========
-    if options[:mode] == "reach"
+    if input_options[:mode] == "reach"
         println("Plotting...")
         tic()
         plot(result)
-        @eval(savefig(@filename_to_png))
+        @eval(savefig(@relpath "heat.png"))
         toc()
     end
 end # function
 
-compute(:δ => 0.001, :N => 3); # warm-up
-compute(:δ => 0.001, :T => 20.0); # benchmark settings (long)
+# Reach tube computation in dense time
+compute(:δ => 1e-3, :N => 3, :mode=>"reach", :verbosity => "info"); # warm-up
+compute(:δ => 1e-3, :T => 20.0, :mode=>"reach", :verbosity => "info"); # benchmark settings (long)

--- a/models/SLICOT/heat/heat.jl
+++ b/models/SLICOT/heat/heat.jl
@@ -3,7 +3,7 @@ Model: heat.jl
 
 This is a 200-variable model.
 =#
-using Reachability, LazySets, MAT
+using Reachability, MAT, Plots
 
 function compute(input_options::Pair{Symbol,<:Any}...)
     # =====================
@@ -45,7 +45,7 @@ function compute(input_options::Pair{Symbol,<:Any}...)
     if options[:mode] == "reach"
         println("Plotting...")
         tic()
-        plot(result) # TODO: project_output
+        plot(result)
         @eval(savefig(@filename_to_png))
         toc()
     end

--- a/models/SLICOT/iss/iss.jl
+++ b/models/SLICOT/iss/iss.jl
@@ -39,7 +39,7 @@ function compute(input_options::Pair{Symbol,<:Any}...)
         :property => LinearConstraintProperty(read(matopen(@relpath "out.mat"), "M")[1,:], 7e-4), # y < 7e-4
 #       :vars => [182], # variable for single block analysis
         :vars => 136:270, # variables needed for property
-        :partition=> [(2*i-1:2*i) for i in 1:135], # 2D blocks
+        :partition => [(2*i-1:2*i) for i in 1:135], # 2D blocks
         :assume_sparse => true,
 #       :projection_matrix => sparse(read(matopen(@relpath "out.mat"), "M")),
         :plot_vars => [0, 182]

--- a/models/SLICOT/iss/iss.jl
+++ b/models/SLICOT/iss/iss.jl
@@ -37,8 +37,9 @@ function compute(input_options::Pair{Symbol,<:Any}...)
     options = merge(Options(
         :mode => "reach",
         :property => LinearConstraintProperty(read(matopen(@relpath "out.mat"), "M")[1,:], 7e-4), # y < 7e-4
-#       :blocks => [@block_id(182)],
-        :blocks => 68:135, # blocks needed for property
+#       :vars => [182], # variable for single block analysis
+        :vars => 136:270, # variables needed for property
+        :partition=> [(2*i-1:2*i) for i in 1:135], # 2D blocks
         :assume_sparse => true,
 #       :projection_matrix => sparse(read(matopen(@relpath "out.mat"), "M")),
         :plot_vars => [0, 182]
@@ -60,5 +61,5 @@ function compute(input_options::Pair{Symbol,<:Any}...)
     end
 end # function
 
-compute(:N => 10, :T => 20.0); # warm-up
+compute(:δ => 0.01, :N => 3); # warm-up
 compute(:δ => 0.01, :T => 20.0); # benchmark settings (long)

--- a/models/SLICOT/iss/iss.jl
+++ b/models/SLICOT/iss/iss.jl
@@ -55,7 +55,7 @@ function compute(input_options::Pair{Symbol,<:Any}...)
         tic()
         #project_output = options[:projection_matrix] != nothing
         #:plot_labels => add_plot_labels(options[:plot_vars], project_output)
-        plot(result) #TODO: labels, project output
+        plot(result)
         @eval(savefig(@filename_to_png))
         toc()
     end

--- a/models/SLICOT/mna1/mna1.jl
+++ b/models/SLICOT/mna1/mna1.jl
@@ -31,7 +31,7 @@ function compute(input_options::Pair{Symbol,<:Any}...)
         :mode => "reach",
         :property => LinearConstraintProperty([1., 0.], 0.5), # x1 < 0.5
         :vars => [1], # variable needed for property
-        :partition=> [(2*i-1:2*i) for i in 1:289], # 2D blocks
+        :partition => [(2*i-1:2*i) for i in 1:289], # 2D blocks
         :plot_vars => [0, 1]
         ), Options(input_options...))
 

--- a/models/SLICOT/mna1/mna1.jl
+++ b/models/SLICOT/mna1/mna1.jl
@@ -30,7 +30,8 @@ function compute(input_options::Pair{Symbol,<:Any}...)
     options = merge(Options(
         :mode => "reach",
         :property => LinearConstraintProperty([1., 0.], 0.5), # x1 < 0.5
-        :blocks => [1],
+        :vars => [1], # variable needed for property
+        :partition=> [(2*i-1:2*i) for i in 1:289], # 2D blocks
         :plot_vars => [0, 1]
         ), Options(input_options...))
 
@@ -49,5 +50,5 @@ function compute(input_options::Pair{Symbol,<:Any}...)
 end # function
 
 
-compute(:δ => 0.001, :T => 0.1); # warm-up
+compute(:δ => 0.001, :N => 3); # warm-up
 compute(:δ => 0.001, :T => 20.0); # benchmark settings (long)

--- a/models/SLICOT/mna1/mna1.jl
+++ b/models/SLICOT/mna1/mna1.jl
@@ -3,7 +3,7 @@ Model: MNA_1.jl
 
 This is a 578-variable model.
 =#
-using Reachability, LazySets, MAT, Plots
+using Reachability, MAT, Plots
 
 function compute(input_options::Pair{Symbol,<:Any}...)
     # =====================
@@ -43,7 +43,7 @@ function compute(input_options::Pair{Symbol,<:Any}...)
     if options[:mode] == "reach"
         println("Plotting...")
         tic()
-        plot(result) # TODO: project_output
+        plot(result)
         @eval(savefig(@filename_to_png))
         toc()
     end

--- a/models/SLICOT/mna5/mna5.jl
+++ b/models/SLICOT/mna5/mna5.jl
@@ -3,7 +3,7 @@ Model: MNA_5.jl
 
 This is a 10913-variable model.
 =#
-using Reachability, LazySets, MAT
+using Reachability, MAT, Plots
 
 function compute(input_options::Pair{Symbol,<:Any}...)
     # =====================

--- a/models/SLICOT/mna5/mna5.jl
+++ b/models/SLICOT/mna5/mna5.jl
@@ -30,7 +30,9 @@ function compute(input_options::Pair{Symbol,<:Any}...)
     options = merge(Options(
         :mode => "reach",
         :property => LinearConstraintProperty([Clause([LinearConstraint([1., 0.], 0.2)]), Clause([LinearConstraint([0., 1.], 0.15)])]), # x1 < 0.2 && x2 < 0.15
-        :blocks => [1],
+#       :vars => [1], # variable for single block analysis
+        :vars => 1:2, # variables needed for property
+        :partition=> [(2*i-1:2*i) for i in 1:5457], # 2D blocks
         :assume_sparse => true,
         :lazy_expm => true,
         :plot_vars => [0, 1]
@@ -54,5 +56,5 @@ function compute(input_options::Pair{Symbol,<:Any}...)
     end
 end # function
 
-compute(:δ => 0.05, :T => 0.1); # warm-up
+compute(:δ => 0.05, :N => 3); # warm-up
 compute(:δ => 0.05, :T => 20.0); # benchmark settings (long)

--- a/models/SLICOT/mna5/mna5.jl
+++ b/models/SLICOT/mna5/mna5.jl
@@ -37,8 +37,10 @@ function compute(input_options::Options)
     elseif input_options[:mode] == "check"
         problem_options = Options(:vars => 1:2, # variables needed for property
                                   :partition => vcat([(2*i-1:2*i) for i in 1:5456], [10913:10913]), # 2D blocks except last (1D)
-                                  :property => LinearConstraintProperty([Clause([LinearConstraint(sparsevec([1], [1.0], 10913), 0.2)]),
-                                                                         Clause([LinearConstraint(sparsevec([2], [1.0], 10913), 0.15)]) ]), # x1 < 0.2 && x2 < 0.15
+                                  :property => LinearConstraintProperty([
+                                      Clause([LinearConstraint(sparsevec([1], [1.0], 10913), 0.2)]),
+                                      Clause([LinearConstraint(sparsevec([2], [1.0], 10913), 0.15)])
+                                      ]), # x1 < 0.2 && x2 < 0.15
                                   :assume_sparse => true,
                                   :lazy_expm => true)
     end

--- a/models/SLICOT/mna5/mna5.jl
+++ b/models/SLICOT/mna5/mna5.jl
@@ -32,7 +32,7 @@ function compute(input_options::Pair{Symbol,<:Any}...)
         :property => LinearConstraintProperty([Clause([LinearConstraint([1., 0.], 0.2)]), Clause([LinearConstraint([0., 1.], 0.15)])]), # x1 < 0.2 && x2 < 0.15
 #       :vars => [1], # variable for single block analysis
         :vars => 1:2, # variables needed for property
-        :partition=> [(2*i-1:2*i) for i in 1:5457], # 2D blocks
+        :partition => vcat([(2*i-1:2*i) for i in 1:5456], [10913:10913]), # 2D blocks except last (1D)
         :assume_sparse => true,
         :lazy_expm => true,
         :plot_vars => [0, 1]

--- a/models/SLICOT/mna5/mna5.jl
+++ b/models/SLICOT/mna5/mna5.jl
@@ -5,7 +5,9 @@ This is a 10913-variable model.
 =#
 using Reachability, MAT, Plots
 
-function compute(input_options::Pair{Symbol,<:Any}...)
+compute(o::Pair{Symbol,<:Any}...) = compute(Options(Dict{Symbol,Any}(o)))
+
+function compute(input_options::Options)
     # =====================
     # Problem specification
     # =====================
@@ -25,39 +27,36 @@ function compute(input_options::Pair{Symbol,<:Any}...)
     # ===============
     # Problem solving
     # ===============
+    if input_options[:mode] == "reach"
+        problem_options = Options(:vars => [1],
+                                  :partition => vcat([(2*i-1:2*i) for i in 1:5456], [10913:10913]), # 2D blocks except last (1D)
+                                  :plot_vars => [0, 1],
+                                  :assume_sparse => true,
+                                  :lazy_expm => true)
 
-    # define solver-specific options
-    options = merge(Options(
-        :mode => "reach",
-        :property => LinearConstraintProperty([Clause([LinearConstraint([1., 0.], 0.2)]),
-                                               Clause([LinearConstraint([0., 1.], 0.15)])]),
-                                               # x1 < 0.2 && x2 < 0.15
-#       :vars => [1], # variable for single block analysis
-        :vars => 1:2, # variables needed for property
-        :partition => vcat([(2*i-1:2*i) for i in 1:5456], [10913:10913]), # 2D blocks except last (1D)
-        :assume_sparse => true,
-        :lazy_expm => true,
-        :plot_vars => [0, 1]
-        ), Options(input_options...))
+    elseif input_options[:mode] == "check"
+        problem_options = Options(:vars => 1:2, # variables needed for property
+                                  :partition => vcat([(2*i-1:2*i) for i in 1:5456], [10913:10913]), # 2D blocks except last (1D)
+                                  :property => LinearConstraintProperty([Clause([LinearConstraint(sparsevec([1], [1.0], 10913), 0.2)]),
+                                                                         Clause([LinearConstraint(sparsevec([2], [1.0], 10913), 0.15)]) ]), # x1 < 0.2 && x2 < 0.15
+                                  :assume_sparse => true,
+                                  :lazy_expm => true)
+    end
 
-    result = solve(S, options)
+    result = solve(S, merge(input_options, problem_options))
 
     # ========
     # Plotting
     # ========
-    if options[:mode] == "reach"
+    if input_options[:mode] == "reach"
         println("Plotting...")
         tic()
-        options_plot = Options(
-            :plot_vars => options[:plot_vars],
-            :plot_name => @filename_to_png
-#           :plot_indices => range_last_x_percent(length(result), 10, 3)
-            )
-        plot(result, options_plot)
-        @eval(savefig(@filename_to_png))
+        plot(result)
+        @eval(savefig(@relpath "mna5.png"))
         toc()
     end
 end # function
 
-compute(:δ => 0.05, :N => 3); # warm-up
-# compute(:δ => 0.05, :T => 20.0); # benchmark settings (long)
+# Reach tube computation in dense time
+compute(:δ => 1e-3, :N => 3, :mode=>"reach", :verbosity => "info"); # warm-up
+compute(:δ => 1e-3, :T => 20.0, :mode=>"reach", :verbosity => "info"); # benchmark settings (long)

--- a/models/SLICOT/mna5/mna5.jl
+++ b/models/SLICOT/mna5/mna5.jl
@@ -57,4 +57,4 @@ function compute(input_options::Pair{Symbol,<:Any}...)
 end # function
 
 compute(:δ => 0.05, :N => 3); # warm-up
-compute(:δ => 0.05, :T => 20.0); # benchmark settings (long)
+# compute(:δ => 0.05, :T => 20.0); # benchmark settings (long)

--- a/models/SLICOT/mna5/mna5.jl
+++ b/models/SLICOT/mna5/mna5.jl
@@ -29,7 +29,9 @@ function compute(input_options::Pair{Symbol,<:Any}...)
     # define solver-specific options
     options = merge(Options(
         :mode => "reach",
-        :property => LinearConstraintProperty([Clause([LinearConstraint([1., 0.], 0.2)]), Clause([LinearConstraint([0., 1.], 0.15)])]), # x1 < 0.2 && x2 < 0.15
+        :property => LinearConstraintProperty([Clause([LinearConstraint([1., 0.], 0.2)]),
+                                               Clause([LinearConstraint([0., 1.], 0.15)])]),
+                                               # x1 < 0.2 && x2 < 0.15
 #       :vars => [1], # variable for single block analysis
         :vars => 1:2, # variables needed for property
         :partition => vcat([(2*i-1:2*i) for i in 1:5456], [10913:10913]), # 2D blocks except last (1D)
@@ -52,6 +54,7 @@ function compute(input_options::Pair{Symbol,<:Any}...)
 #           :plot_indices => range_last_x_percent(length(result), 10, 3)
             )
         plot(result, options_plot)
+        @eval(savefig(@filename_to_png))
         toc()
     end
 end # function

--- a/models/SLICOT/motor/motor.jl
+++ b/models/SLICOT/motor/motor.jl
@@ -39,7 +39,9 @@ function compute(input_options::Pair{Symbol,<:Any}...)
                          Clause([LinearConstraint([1.; zeros(7)], 0.35),
                                  LinearConstraint([zeros(4); 1.; zeros(3)], 0.45)])),
                                  # x1 < 0.35 || x5 < 0.45
-        :blocks => [1, 3], # blocks needed for property
+#       :vars => [5], # variable for single block analysis
+        :vars => [1, 5], # variables needed for property
+        :partition=> [(2*i-1:2*i) for i in 1:4], # 2D blocks
         :plot_vars => [0, 5]
         ), Options(input_options...))
 
@@ -57,5 +59,5 @@ function compute(input_options::Pair{Symbol,<:Any}...)
     end
 end # function
 
-compute(:N => 100, :T => 1.0); # warm-up
+compute(:δ => 0.001, :N => 3); # warm-up
 compute(:δ => 0.001, :T => 20.0); # benchmark settings (long)

--- a/models/SLICOT/motor/motor.jl
+++ b/models/SLICOT/motor/motor.jl
@@ -38,13 +38,13 @@ function compute(input_options::Options)
         problem_options = Options(:vars => [5],
                                   :partition => [(2*i-1:2*i) for i in 1:4], # 2D blocks
                                   :plot_vars => [0, 5])
-
     elseif input_options[:mode] == "check"
         problem_options = Options(:vars => [1, 5], # variables needed for property
                                   :partition => [(2*i-1:2*i) for i in 1:4], # 2D blocks
                                   :property => LinearConstraintProperty(
                                                    Clause([LinearConstraint([1.; zeros(7)], 0.35),
                                                            LinearConstraint([zeros(4); 1.; zeros(3)], 0.45)]))) # x1 < 0.35 || x5 < 0.45
+    end
 
     result = solve(S, merge(input_options, problem_options))
 

--- a/models/SLICOT/motor/motor.jl
+++ b/models/SLICOT/motor/motor.jl
@@ -54,7 +54,7 @@ function compute(input_options::Pair{Symbol,<:Any}...)
         println("Plotting...")
         tic()
         plot(result)
-        @eval(savefig("motor.jl"))
+        @eval(savefig(@filename_to_png))
         toc()
     end
 end # function

--- a/models/SLICOT/motor/motor.jl
+++ b/models/SLICOT/motor/motor.jl
@@ -41,7 +41,7 @@ function compute(input_options::Pair{Symbol,<:Any}...)
                                  # x1 < 0.35 || x5 < 0.45
 #       :vars => [5], # variable for single block analysis
         :vars => [1, 5], # variables needed for property
-        :partition=> [(2*i-1:2*i) for i in 1:4], # 2D blocks
+        :partition => [(2*i-1:2*i) for i in 1:4], # 2D blocks
         :plot_vars => [0, 5]
         ), Options(input_options...))
 

--- a/models/SLICOT/pde/pde.jl
+++ b/models/SLICOT/pde/pde.jl
@@ -38,7 +38,7 @@ function compute(input_options::Options)
                                   # :projection_matrix => sparse(read(matopen(@relpath "out.mat"), "M"))
 
     elseif input_options[:mode] == "check"
-        problem_options = Options(:vars => 1:42, # variables needed for property
+        problem_options = Options(:vars => 1:84, # variables needed for property
                                   :partition => [(2*i-1:2*i) for i in 1:42], # 2D blocks
                                   :property => LinearConstraintProperty(read(matopen(@relpath "out.mat"), "M")[1,:], 12.)) # y < 12
 

--- a/models/SLICOT/pde/pde.jl
+++ b/models/SLICOT/pde/pde.jl
@@ -1,7 +1,7 @@
 #=
 Model: pde.jl
 =#
-using Reachability, LazySets, MAT
+using Reachability, MAT, Plots
 
 function compute(input_options::Pair{Symbol,<:Any}...)
     # =====================
@@ -47,13 +47,11 @@ function compute(input_options::Pair{Symbol,<:Any}...)
     # Plotting
     # ========
     if options[:mode] == "reach"
-        if options[:mode] == "reach"
-            println("Plotting...")
-            tic()
-            plot(result) # TODO output labels
-            @eval(savefig("motor.jl"))
-            toc()
-        end
+        println("Plotting...")
+        tic()
+        plot(result)
+        @eval(savefig(@filename_to_png))
+        toc()
     end
 end # function
 

--- a/models/SLICOT/pde/pde.jl
+++ b/models/SLICOT/pde/pde.jl
@@ -36,11 +36,11 @@ function compute(input_options::Options)
                                   :partition => [(2*i-1:2*i) for i in 1:42], # 2D blocks
                                   :plot_vars => [0, 1])
                                   # :projection_matrix => sparse(read(matopen(@relpath "out.mat"), "M"))
-
     elseif input_options[:mode] == "check"
         problem_options = Options(:vars => 1:84, # variables needed for property
                                   :partition => [(2*i-1:2*i) for i in 1:42], # 2D blocks
                                   :property => LinearConstraintProperty(read(matopen(@relpath "out.mat"), "M")[1,:], 12.)) # y < 12
+    end
 
     result = solve(S, merge(input_options, problem_options))
 

--- a/models/SLICOT/pde/pde.jl
+++ b/models/SLICOT/pde/pde.jl
@@ -36,7 +36,7 @@ function compute(input_options::Pair{Symbol,<:Any}...)
         :property => LinearConstraintProperty(read(matopen(@relpath "out.mat"), "M")[1,:], 12.), # y < 12
 #       :vars => [1], # variable for single block analysis
         :vars => 1:42, # variables needed for property
-        :partition=> [(2*i-1:2*i) for i in 1:42], # 2D blocks
+        :partition => [(2*i-1:2*i) for i in 1:42], # 2D blocks
 #       :projection_matrix => sparse(read(matopen(@relpath "out.mat"), "M")),
         :plot_vars => [0, 1]
         ), Options(input_options...))

--- a/models/SLICOT/pde/pde.jl
+++ b/models/SLICOT/pde/pde.jl
@@ -34,7 +34,9 @@ function compute(input_options::Pair{Symbol,<:Any}...)
     options = merge(Options(
         :mode => "reach",
         :property => LinearConstraintProperty(read(matopen(@relpath "out.mat"), "M")[1,:], 12.), # y < 12
-#       :blocks => [1],
+#       :vars => [1], # variable for single block analysis
+        :vars => 1:42, # variables needed for property
+        :partition=> [(2*i-1:2*i) for i in 1:42], # 2D blocks
 #       :projection_matrix => sparse(read(matopen(@relpath "out.mat"), "M")),
         :plot_vars => [0, 1]
         ), Options(input_options...))
@@ -55,5 +57,5 @@ function compute(input_options::Pair{Symbol,<:Any}...)
     end
 end # function
 
-compute(:N => 100, :T => 1.0); # warm-up
+compute(:δ => 0.003, :N => 3); # warm-up
 compute(:δ => 0.003, :T => 20.0); # benchmark settings (long)


### PR DESCRIPTION
Closes #12.

---

* [ ] Compare reach plots.
    * [x] Got the same reach plots except MNA5 (skipped).
    * [ ] Compare reach plots for MNA5.
* [ ] Compare runtimes for reach (single block: new, [slow w/ `lazy_sih` / slow w/o `lazy_sih`]).
   * [x] Motor: 0.76 [2.27 / 2.0] seconds (old: 1.06 seconds)
   * [x] Building: 2.08 [8.75 / 8.43] seconds (old: 4.49 seconds)
   * [x] PDE: 2.35 [3.69 / 3.93] seconds (old: 4.43 seconds)
   * [x] CD player: 13 [different delta: 3.1 / 2.9] seconds (old: n/a)
   * [x] Heat: 9.15 [37 / 39] seconds (old: 24 seconds)
   * [x] ISS: 1.94 [4.23 / 4.72] seconds (old: 2.46 seconds)
   * [x] Beam: 28 [73 / 79] seconds (old: 54 seconds)
   * [x] MNA1: 90 [175 / 181] seconds (old: 140 seconds)
   * [x] FOM: 6.64 [8.5 / 7] seconds (old: 10 seconds)
   * [ ] MNA5: ? seconds (old: 1380 seconds)
* [x] Properties should be n-dimensional.
* [ ] Compare property checking.
   * [x] Motor: 2.87 seconds (old: 1.62)
   * [x] Building: does **not** work with `δ = 3e-3` anymore (old: 0.87)
      * I tracked it down to issue 42 in `LazySets`. Apparently there was a bug in the old version.
   * [x] PDE: 1030 seconds (old: 1030)
   * [x] CD player
   * [x] Heat: 15 seconds (old: 14.8)
   * [x] ISS
   * [x] Beam: 745 seconds (old: 857)
   * [x] MNA1: 263 seconds (old: 287)
   * [x] FOM
   * [ ] MNA5: I stopped it after > 40 minutes (old: 392 seconds)
* [x] Change `vars` for all models to single variable analysis.
* [x] Find out why reach has gotten slower.