### PR TITLE
HSCC2019

### DIFF
--- a/models/HSCC2019/create_figure_2.jl
+++ b/models/HSCC2019/create_figure_2.jl
@@ -6,6 +6,11 @@
 # Note that the code uses random numbers, so the resulting plots and the runtime will likely differ.
 
 using LazySets, LazySets.Approximations, Plots
+if VERSION >= v"0.7"
+    using SparseArrays
+else
+    using Compat
+end
 
 ENV["GKSwstype"] = "100"
 
@@ -15,7 +20,7 @@ X0 = BallInf(ones(n), 0.1);
 U = Ball2(zeros(m), 1.2);
 Y = ConvexHull(SparseMatrixExp(A * δ) * X0 ⊕ δ * B *U, X0);
 π = spzeros(2, n) ; π[1, 1] = π[2, 50] = 1;
-res = Vector{HPolygon{Float64}}(3)
+res = Vector{HPolygon{Float64}}(undef, 3)
 εs = [Inf, 0.1, 0.01]
 println("warm-up runtimes:")
 for (i, ε) in enumerate(εs)

--- a/models/HSCC2019/create_figure_3.jl
+++ b/models/HSCC2019/create_figure_3.jl
@@ -4,6 +4,12 @@
 #     include("create_figure_3.jl")
 
 using LazySets, Plots
+if VERSION >= v"0.7"
+    using LinearAlgebra
+    expm = exp
+else
+    using Compat
+end
 
 #disable graphics output in GR - https://github.com/JuliaPlots/Plots.jl/issues/1182
 ENV["GKSwstype"] = "100"
@@ -20,7 +26,7 @@ function reach_continuous(A, X0, δ, μ, T, max_order)
     N = floor(Int, T/δ)
 
     # preallocate array
-    R = Vector{LazySet}(N)
+    R = Vector{LazySet}(undef, N)
     if N == 0
         return R
     end
@@ -31,13 +37,13 @@ function reach_continuous(A, X0, δ, μ, T, max_order)
     c = X0.center
     gens = hcat(ϕp * X0.generators, ϕm * c, ϕm * X0.generators)
     R[1] = minkowski_sum(Zonotope(ϕp * c, gens),
-                         Zonotope(zeros(n), (α + β)*eye(n)))
+                         Zonotope(zeros(n), Matrix((α + β)*I, n, n)))
     if order(R[1]) > max_order
         R[1] = reduce_order(R[1], max_order)
     end
 
     # set recurrence for [δ, 2δ], ..., [(N-1)δ, Nδ]
-    ballβ = Zonotope(zeros(n), β*eye(n))
+    ballβ = Zonotope(zeros(n), Matrix(β*I, n, n))
     for i in 2:N
         R[i] = minkowski_sum(linear_map(ϕ, R[i-1]), ballβ)
         if order(R[i]) > max_order


### PR DESCRIPTION
See #39.

* We have to decide whether to use `expm` (Julia v0.6) or `exp` (new Julia) in the paper.
* The script for Figure 5 requires #50 first.
* I also noticed that the reachability code [in the `LazySets` manual](https://juliareach.github.io/LazySets.jl/latest/man/reach_zonotopes.html) is different.