### PR TITLE
Revise Laub Loomis benchmark settings

### DIFF
--- a/models/ARCH/NLN/LaubLoomis/laubloomis_benchmark.jl
+++ b/models/ARCH/NLN/LaubLoomis/laubloomis_benchmark.jl
@@ -11,8 +11,8 @@ include("laubloomis_TMJets.jl")
 
 # --- Case 1: smaller initial states ---
 
-𝑂₁ = Options(:t0=>0.0, :T=>20.0, :W=>0.01, :abs_tol=>1e-6,
-              :orderT=>8, :orderQ=>2, :maxsteps=>1000, :property=>x->x[4] < 4.5)
+𝑂₁ = Options(:t0=>0.0, :T=>20.0, :W=>0.01, :abs_tol=>1e-18,
+              :orderT=>12, :orderQ=>2, :maxsteps=>1000, :property=>x->x[4] < 4.5)
 
 # first run
 tTM, xTM = laubloomis_TMJets(; t0=𝑂₁[:t0], T=𝑂₁[:T], W=𝑂₁[:W],
@@ -29,8 +29,8 @@ SUITE["LaubLoomis"]["W=0.01"] = @benchmarkable laubloomis_TMJets(; t0=$𝑂₁[:
 
 # --- Case 2: larger initial states ---
 
-𝑂₂ = Options(:t0=>0.0, :T=>20.0, :W=>0.1, :abs_tol=>1e-3,
-              :orderT=>4, :orderQ=>2, :maxsteps=>1000, :property=>x->x[4] < 5.0)
+𝑂₂ = Options(:t0=>0.0, :T=>20.0, :W=>0.1, :abs_tol=>1e-24,
+              :orderT=>16, :orderQ=>2, :maxsteps=>1000, :property=>x->x[4] < 5.0)
 
 # first run
 tTM, xTM = laubloomis_TMJets(; t0=𝑂₂[:t0], T=𝑂₂[:T], W=𝑂₂[:W],


### PR DESCRIPTION
```julia
julia> include("models/ARCH/NLN/LaubLoomis/laubloomis_benchmark.jl")
(1/1) benchmarking "LaubLoomis"...
  (1/2) benchmarking "W=0.01"...
  done (took 13.483893198 seconds)
  (2/2) benchmarking "W=0.1"...
  done (took 19.510441722 seconds)
done (took 33.52159346 seconds)
minimum time for each benchmark:
1-element BenchmarkTools.BenchmarkGroup:
  tags: []
  "LaubLoomis" => 2-element BenchmarkTools.BenchmarkGroup:
          tags: []
          "W=0.01" => TrialEstimate(12.932 s)

          "W=0.1" => TrialEstimate(18.972 s)
median time for each benchmark:
1-element BenchmarkTools.BenchmarkGroup:
  tags: []
  "LaubLoomis" => 2-element BenchmarkTools.BenchmarkGroup:
          tags: []
          "W=0.01" => TrialEstimate(12.932 s)
          "W=0.1" => TrialEstimate(18.972 s)
```