### PR TITLE
Adapt discrete time steps for ARCH-COMP 2019

### DIFF
--- a/models/ARCH/AFF/Building/building_BFFPSV18.jl
+++ b/models/ARCH/AFF/Building/building_BFFPSV18.jl
@@ -11,7 +11,7 @@ include("building.jl")
 𝑂_dense_BLDF01 = Options(:vars => [25], :partition => [1:24, [25], 26:48],
                          :δ => 0.003, :block_options_init => LazySets.LinearMap)
 𝑂_discrete_BLDF01 =
-    merge(𝑂_dense_BLDF01, Options(:discretization => "nobloating", :δ => 0.005))
+    merge(𝑂_dense_BLDF01, Options(:discretization => "nobloating", :δ => 0.01))
 
 # single run to verify that specification holds
 sol_BLDF01_dense = solve(build_TV, 𝑂_BLDF01, op=BFFPSV18(𝑂_dense_BLDF01))

--- a/models/ARCH/AFF/Platooning/Platooning_benchmark.jl
+++ b/models/ARCH/AFF/Platooning/Platooning_benchmark.jl
@@ -29,7 +29,7 @@ options_PLAN01_UNB50[:mode] = "check"
 𝑂_dense_options_PLAD01_BND42 = merge(𝑂_common, Options(:δ => 0.01))
 𝑂_dense_options_PLAD01_BND30 = merge(𝑂_common, Options(:δ => 0.00001))
 𝑂_dense_options_PLAN01_UNB50 = merge(𝑂_common, Options(:δ => 0.03))
-𝑂_discrete = merge(𝑂_common, Options(:discretization => "nobloating", :δ => 0.05))
+𝑂_discrete = merge(𝑂_common, Options(:discretization => "nobloating", :δ => 0.1))
 
 opC_dense_PLAD01_BND42 = BFFPSV18(𝑂_dense_options_PLAD01_BND42)
 opC_dense_PLAD01_BND30 = BFFPSV18(𝑂_dense_options_PLAD01_BND30)

--- a/models/ARCH/AFF/Rendezvous/SpacecraftRendezvous_benchmark.jl
+++ b/models/ARCH/AFF/Rendezvous/SpacecraftRendezvous_benchmark.jl
@@ -68,10 +68,10 @@ res = solve(SRA01, options, opC_discrete, opD)
 # @assert res.satisfied  # TODO NEW SETTING
 # res = solve(SRA08, options, opC_discrete, opD)
 # @assert res.satisfied  # TODO NEW SETTING
-# res = solve(SRU01, options, opC_dense, opD)
-# @assert res.satisfied  # TODO NEW SETTING
-# res = solve(SRU01, options, opC_discrete, opD)
-# @assert res.satisfied  # TODO NEW SETTING
+res = solve(SRU01, options, opC_dense, opD)
+@assert !res.satisfied
+res = solve(SRU01, options, opC_discrete, opD)
+@assert !res.satisfied
 res = solve(SRU02, options, opC_dense, opD)
 @assert !res.satisfied
 res = solve(SRU02, options, opC_discrete, opD)
@@ -114,7 +114,7 @@ SUITE["Spacecraft"]["SRA01-SR02", "discrete"] =
 #     @benchmarkable solve($SRA08, $options, $opC_dense, $opD)
 # SUITE["Spacecraft"]["SRA08-SR02", "discrete"] =
 #     @benchmarkable solve($SRA08, $options, $opC_discrete, $opD)
-# SUITE["Spacecraft"]["SRU01-SR02", "dense"] =
+SUITE["Spacecraft"]["SRU01-SR02", "dense"] =
     @benchmarkable solve($SRU01, $options, $opC_dense, $opD)
 SUITE["Spacecraft"]["SRU01-SR02", "discrete"] =
     @benchmarkable solve($SRU01, $options, $opC_discrete, $opD)

--- a/models/ARCH/AFF/SpaceStation/iss_BFFPSV18.jl
+++ b/models/ARCH/AFF/SpaceStation/iss_BFFPSV18.jl
@@ -16,9 +16,9 @@ include("iss.jl")
 𝑂_dense_ISU = Options(:δ=>5e-3, :vars=>136:270, :assume_sparse=>true)
 𝑂_dense_ISS01 = Options(:δ=>6e-4, :vars=>136:270, :assume_sparse=>true,
                         :lazy_inputs_interval=>-1, :partition=>[1:135, 136:270])
-𝑂_discrete_ISU = Options(:discretization=>"nobloating", :δ=>5e-3,
+𝑂_discrete_ISU = Options(:discretization=>"nobloating", :δ=>0.01,
                          :vars=>136:270, :assume_sparse=>true)
-𝑂_discrete_ISS01 = Options(:discretization=>"nobloating", :δ=>5e-3,
+𝑂_discrete_ISS01 = Options(:discretization=>"nobloating", :δ=>0.01,
                            :vars=>136:270, :assume_sparse=>true,
                            :lazy_inputs_interval=>-1,
                            :partition=>[1:135, 136:270])


### PR DESCRIPTION
This also adds a missing case to the benchmarks.