### PR TITLE
Update nonlinear bouncing ball

### DIFF
--- a/models/NonlinearBouncingBall/bball.jl
+++ b/models/NonlinearBouncingBall/bball.jl
@@ -63,7 +63,7 @@ function bouncing_ball()
 
     ℋ = HybridSystem(automaton, modes, resetmaps, switchings)
 
-    # initial condition in mode one
+    # initial condition in mode two
     X0 = Hyperrectangle(low=[4.9, -0.2], high=[5.1, 0.0])
 
     initial_condition = [(2, X0)]  # initial condition in the "down" mode

--- a/models/NonlinearBouncingBall/bball.jl
+++ b/models/NonlinearBouncingBall/bball.jl
@@ -54,17 +54,17 @@ function bouncing_ball()
     Rα = ConstrainedLinearMap(A, Gα)
     Rβ = ConstrainedIdentityMap(2, Gβ)
 
-    #resetmaps
+    # resetmaps
     resetmaps = [Rα, Rβ]
 
-    # switching
+    # switchings
     switching = AutonomousSwitching()
     switchings = fill(switching, 2)
 
     ℋ = HybridSystem(automaton, modes, resetmaps, switchings)
 
-    #initial condition in mode one
-    X0= Hyperrectangle(low=[4.9, -0.2], high=[5.1, 0.0])
+    # initial condition in mode one
+    X0 = Hyperrectangle(low=[4.9, -0.2], high=[5.1, 0.0])
 
     initial_condition = [(2, X0)]  # initial condition in the "down" mode
 


### PR DESCRIPTION
Minor tweaks in the nonlinear bouncing ball example.

<img width="593" alt="Screen Shot 2019-04-07 at 09 43 17" src="https://user-images.githubusercontent.com/12424594/55683789-05a17580-591a-11e9-957f-67c9d67c80d3.png">


```julia
julia> include("models/NonlinearBouncingBall/bball.jl")
[warn] Several option aliases were used for aliases Symbol[:check_invariant_intersection].
[info] Reachable States Computation...
[ Info: Maximum number of integration steps reached; exiting.
[info] elapsed time: 4.590e+00 seconds
[info] Considering transition: HybridSystems.LightTransition{LightGraphs.SimpleGraphs.SimpleEdge{Int64}}(Edge 2 => 1, 1)
[info] Reachable States Computation...
[ Info: Maximum number of integration steps reached; exiting.
[info] elapsed time: 2.369e+00 seconds
[info] Considering transition: HybridSystems.LightTransition{LightGraphs.SimpleGraphs.SimpleEdge{Int64}}(Edge 1 => 2, 2)
[info] Reachable States Computation...
[info] elapsed time: 1.689e+00 seconds
[info] Considering transition: HybridSystems.LightTransition{LightGraphs.SimpleGraphs.SimpleEdge{Int64}}(Edge 2 => 1, 1)

[info] Reachable States Computation...
[info] elapsed time: 6.079e-01 seconds
[info] Considering transition: HybridSystems.LightTransition{LightGraphs.SimpleGraphs.SimpleEdge{Int64}}(Edge 1 => 2, 2)
 14.547003 seconds (87.06 M allocations: 4.848 GiB, 16.08% gc time)
```


 