### PR TITLE
#91 - Revise filtered-oscillator model

### DIFF
--- a/models/FilteredOscillator/FilteredOscillator.jl
+++ b/models/FilteredOscillator/FilteredOscillator.jl
@@ -4,8 +4,8 @@
 # See: https://flowstar.org/benchmarks/filtered-oscillator/
 # ==============================================================================
 
-using HybridSystems, MathematicalSystems, LazySets, Reachability, Polyhedra, Optim
-using LinearAlgebra, SparseArrays
+using HybridSystems, MathematicalSystems, LazySets, LinearAlgebra, Reachability
+using Polyhedra, Optim
 
 import LazySets.HalfSpace
 import LazySets.Approximations: overapproximate, OctDirections

--- a/models/FilteredOscillator/FilteredOscillator.jl
+++ b/models/FilteredOscillator/FilteredOscillator.jl
@@ -125,7 +125,7 @@ function filtered_oscillator(n0::Int=4,
 
     HS = HybridSystem(a, m, r, s)
 
-    # initial condition in mode 1
+    # initial condition in mode 3
     low = [0.2; -0.1; zeros(n1)]
     high = [0.3; 0.1; zeros(n1)]
     if one_loop_iteration

--- a/models/FilteredOscillator/FilteredOscillator.jl
+++ b/models/FilteredOscillator/FilteredOscillator.jl
@@ -88,38 +88,35 @@ function filtered_oscillator(n0::Int=4,
 
     # transitions
 
-    # common resets
-    A_trans = Matrix(1.0I, n, n)
-
     # transition l3 -> l4
     X_l3l4 = HPolyhedron([HalfSpace([-1.0; 0.0; z], 0.0),  # x >= 0
                           HalfSpace([-0.714286; -1.0; z], 0.0),  # 0.714286*x + y >= 0
                           HalfSpace([0.714286; 1.0; z], 0.0)])  # 0.714286*x + y <= 0
     if one_loop_iteration
-        A_trans_34 = copy(A_trans)
+        A_trans_34 = Matrix(1.0I, n, n)
         A_trans_34[n, n] = 2.  # k' = k * 2
+        r1 = ConstrainedLinearMap(A_trans_34, X_l3l4)
     else
-        A_trans_34 = A_trans
+        r1 = ConstrainedIdentityMap(n, X_l3l4)
     end
-    r1 = ConstrainedLinearMap(A_trans_34, X_l3l4)
 
     # transition l4 -> l2
     X_l4l2 = HPolyhedron([HalfSpace([0.714286; 1.0; z], 0.0),  # 0.714286*x + y <= 0
                           HalfSpace([-1.0; 0.0; z], 0.0),  # x >= 0
                           HalfSpace([1.0; 0.0; z], 0.0)])  # x <= 0
-    r2 = ConstrainedLinearMap(A_trans, X_l4l2)
+    r2 = ConstrainedIdentityMap(n, X_l4l2)
 
     # transition l2 -> l1
     X_l2l1 = HPolyhedron([HalfSpace([1.0; 0.0; z], 0.0),  # x <= 0
                           HalfSpace([-0.714286; -1.0; z], 0.0),  # 0.714286*x + y >= 0
                           HalfSpace([0.714286; 1.0; z], 0.0)])  # 0.714286*x + y <= 0
-    r3 = ConstrainedLinearMap(A_trans, X_l2l1)
+    r3 = ConstrainedIdentityMap(n, X_l2l1)
 
     # transition l1 -> l3
     X_l1l3 = HPolyhedron([HalfSpace([-0.714286; -1.0; z], 0.0),  # 0.714286*x + y >= 0
                           HalfSpace([-1.0; 0.0; z], 0.0),  # x >= 0
                           HalfSpace([1.0; 0.0; z], 0.0)])  # x <= 0
-    r4 = ConstrainedLinearMap(A_trans, X_l1l3)
+    r4 = ConstrainedIdentityMap(n, X_l1l3)
 
     r = [r1, r2, r3, r4]
 

--- a/models/FilteredOscillator/FilteredOscillator.jl
+++ b/models/FilteredOscillator/FilteredOscillator.jl
@@ -136,7 +136,12 @@ function filtered_oscillator(n0::Int=4,
 
     problem = InitialValueProblem(HS, [(3, X0)])
 
-    options = Options(:T=>time_horizon, :mode=>"reach", :verbosity=>0)
+    # safety property
+    border = HPolyhedron([HalfSpace([0.0; -1.0; z], -0.5)])  # y >= 0.5
+    property = BadStatesProperty(border)
+
+    options = Options(:T=>time_horizon, :mode=>"reach", :property=>property,
+                      :verbosity=>0)
 
     solver_options = Options(:vars=>1:n, :δ=>0.01, :plot_vars=>[1, 2],
                              :ε_proj=>0.001, :project_reachset=>false)


### PR DESCRIPTION
Closes #91.

* documented `one_loop_iteration` option
* used `ConstrainedIdentityMap` instead of `ConstrainedLinearMap` with identity matrix
* fixed a bug: There was an assignment in `A_trans_34` independent of the option `one_loop_iteration`.
* reordered imports (model-specific vs. analysis-specific; dropped unused `SparseArrays` import)
* fixed typo in comment
* added safety property

CC @kostakoida